### PR TITLE
Fix text processing pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix text processing pipeline (#70)
+
 ## 1.1.0 (2020-08-24)
 
 * Add "Unlock Window" option to context menu - SammyJames

--- a/Glass/Modules/TextProcessing.lua
+++ b/Glass/Modules/TextProcessing.lua
@@ -85,7 +85,8 @@ function TP:ProcessText(text)
 
   for _, processor in ipairs(TEXT_PROCESSORS) do
     -- Prevent failing processors from bringing down the whole pipeline
-    local retOk, retVal = pcall(processor, text)
+    local retOk, retVal = pcall(processor, result)
+
     if retOk then
       result = retVal
     end


### PR DESCRIPTION
Issue ticket: None

**If applied, this PR will...**
Fix bug with the text processing pipeline

**Please provide detail on the technical changes, if relevant**
Only the last processor is changing the result. This fixes that and now all
processors contribute to the final text result.

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated