### PR TITLE
Fix dependency issues

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -3,6 +3,7 @@ enable-nolib-creation: no
 
 externals:
     libs/LibStub: https://repos.wowace.com/wow/libstub/trunk
+    libs/CallbackHandler-1.0: https://repos.wowace.com/wow/callbackhandler/trunk/CallbackHandler-1.0
     libs/AceAddon-3.0: https://repos.wowace.com/wow/ace3/trunk/AceAddon-3.0
     libs/AceConfig-3.0: https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0
     libs/AceConsole-3.0: https://repos.wowace.com/wow/ace3/trunk/AceConsole-3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix text processing pipeline (#70)
 * Fix jittery animations (#71)
+* Fix dependency issues (#72)
 
 ## 1.1.0 (2020-08-24)
 

--- a/Glass.toc
+++ b/Glass.toc
@@ -12,6 +12,8 @@
 
 # Libs
 libs\LibStub\LibStub.lua
+libs\CallbackHandler-1.0\CallbackHandler-1.0.xml
+libs\LibSharedMedia-3.0\lib.xml
 libs\AceGUI-3.0\AceGUI-3.0.xml
 
 libs\AceAddon-3.0\AceAddon-3.0.xml
@@ -21,7 +23,6 @@ libs\AceDB-3.0\AceDB-3.0.xml
 libs\AceDBOptions-3.0\AceDBOptions-3.0.xml
 libs\AceGUI-3.0-SharedMediaWidgets\widget.xml
 libs\AceHook-3.0\AceHook-3.0.xml
-libs\LibSharedMedia-3.0\lib.xml
 libs\lodash.wow\lodash.wow.xml
 
 # Glass


### PR DESCRIPTION
Issue ticket: None

**If applied, this PR will...**
Fix the dependency issue causing Glass to crash on start when there are no other
addons loaded.

**Please provide detail on the technical changes, if relevant**

* Add CallbackHandler-1.0 to the dependency list
* Shift LibSharedMedia up on the dependency loading order

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated