### PR TITLE
Add support for third-party chat links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.0-alpha1 (2020-09-04)
+
+* Add support for third-party chat links (#90)
+
 ## 1.2.1 (2020-09-01)
 
 * Fix conflict with ElvUI Mover

--- a/Glass/Modules/Hyperlinks.lua
+++ b/Glass/Modules/Hyperlinks.lua
@@ -9,7 +9,6 @@ local HYPERLINK_LEAVE = Constants.EVENTS.HYPERLINK_LEAVE
 local BattlePetToolTip_ShowLink = BattlePetToolTip_ShowLink
 local BattlePetTooltip = BattlePetTooltip
 local GameTooltip = GameTooltip
-local SetItemRef = SetItemRef
 local ShowUIPanel = ShowUIPanel
 local UIParent = UIParent
 -- luacheck: pop
@@ -33,7 +32,9 @@ end
 function Hyperlinks:OnEnable()
   Core:Subscribe(HYPERLINK_CLICK, function (payload)
     local link, text, button = unpack(payload)
-    SetItemRef(link, text, button)
+    -- Use global reference in case some addon has hooked into it for custom
+    -- hyperlinks (e.g. Mythic Dungeon Tools, Prat)
+    _G.SetItemRef(link, text, button)
   end)
 
   Core:Subscribe(HYPERLINK_ENTER, function (payload)


### PR DESCRIPTION
Issue ticket #89, #32 

**If applied, this PR will...**
Add support for other addon's chat links. This includes Prat's URL links and Mythic Dungeon Tool's route links.

**Please provide detail on the technical changes, if relevant**
The thing preventing this was a local reference to `SetItemRef`. At the point when Glass loads, `SetItemRef` points to the original function. But other addons hook and replace `SetItemRef` to add their own links. The change is simply to use the global reference `_G.SetItemRef` instead of creating a local reference.

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated
