### PR TITLE
#93 - Force chatStyle to Classic style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Force chatStyle to classic (#94)
+
 ## 1.3.0-alpha2 (2020-09-06)
 
 * Improve scrolling behavior (#92)

--- a/Glass/Modules/UIManager.lua
+++ b/Glass/Modules/UIManager.lua
@@ -1,4 +1,4 @@
-local Core = unpack(select(2, ...))
+local Core, _, Utils = unpack(select(2, ...))
 local UIManager = Core:GetModule("UIManager")
 
 local CreateChatDock = Core.Components.CreateChatDock
@@ -11,6 +11,7 @@ local CreateSlidingMessageFramePool = Core.Components.CreateSlidingMessageFrameP
 
 -- luacheck: push ignore 113
 local BNToastFrame = BNToastFrame
+local C_CVar = C_CVar
 local ChatAlertFrame = ChatAlertFrame
 local ChatFrameChannelButton = ChatFrameChannelButton
 local ChatFrameMenuButton = ChatFrameMenuButton
@@ -68,6 +69,16 @@ function UIManager:OnEnable()
   QuickJoinToastButton:Hide()
   ChatFrameChannelButton:Hide()
   ChatFrameMenuButton:Hide()
+
+  -- Force classic chat style
+  if C_CVar.GetCVar("chatStyle") ~= "classic" then
+    C_CVar.SetCVar("chatStyle", "classic")
+    Utils.notify('Chat Style set to "Classic Style"')
+
+    -- Resets the background that IM style causes
+    self.editBox:SetFocus()
+    self.editBox:ClearFocus()
+  end
 
   -- Handle temporary chat frames (whisper popout, pet battle)
   self:RawHook("FCF_OpenTemporaryWindow", function (...)

--- a/Glass/init.lua
+++ b/Glass/init.lua
@@ -11,7 +11,6 @@ AddonVars[2] = Constants
 AddonVars[3] = Utils
 _G[AddonName] = Core
 
-
 -- Core
 Core.Libs = {
   AceConfig = _G.LibStub("AceConfig-3.0"),

--- a/Glass/utils.lua
+++ b/Glass/utils.lua
@@ -15,3 +15,9 @@ Utils.print = function (str, t)
     table.insert(Core.printBuffer, {str, t})
   end
 end
+
+---
+-- Print's Glass notification messages
+Utils.notify = function (message)
+  print("|c00DFBA69Glass|r: ", message)
+end

--- a/Glass/utils.lua
+++ b/Glass/utils.lua
@@ -17,7 +17,7 @@ Utils.print = function (str, t)
 end
 
 ---
--- Print's Glass notification messages
+-- Prints Glass' notification messages
 Utils.notify = function (message)
   print("|c00DFBA69Glass|r: ", message)
 end


### PR DESCRIPTION
Issue ticket #93

**If applied, this PR will...**
Force the chatStyle setting to use "Classic Style"

**Please provide detail on the technical changes, if relevant**
Because Glass isn't compatible with IM Style.

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated