### PR TITLE
Fix saved anchor point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix AceDB issues
+
 ## 1.4.0 (2020-09-07)
 
 * Add classic support (#95)

--- a/Glass/Components/MoverFrame.lua
+++ b/Glass/Components/MoverFrame.lua
@@ -17,7 +17,7 @@ local Mixin = Mixin
 function MoverFrameMixin:Init()
   local editBoxMargin = 35
   local pos = Core.db.profile.positionAnchor
-  self:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.xOfs, pos.yOfs)
+  self:SetPoint(pos.point, nil, pos.relativePoint, pos.xOfs, pos.yOfs)
   self:SetWidth(Core.db.profile.frameWidth)
   self:SetHeight(Core.db.profile.frameHeight + editBoxMargin)
 
@@ -36,10 +36,9 @@ function MoverFrameMixin:Init()
     self:EnableMouse(false)
     self:SetMovable(false)
 
-    local point, relativeTo, relativePoint, xOfs, yOfs = self:GetPoint(1)
+    local point, _, relativePoint, xOfs, yOfs = self:GetPoint(1)
     local position = {
       point = point,
-      relativeTo = relativeTo,
       relativePoint = relativePoint,
       xOfs = xOfs,
       yOfs = yOfs
@@ -66,7 +65,7 @@ function MoverFrameMixin:Init()
 
   Core:Subscribe(REFRESH_CONFIG, function ()
     pos = Core.db.profile.positionAnchor
-    self:SetPoint(pos.point, pos.relativeTo, pos.relativePoint, pos.xOfs, pos.yOfs)
+    self:SetPoint(pos.point, nil, pos.relativePoint, pos.xOfs, pos.yOfs)
   end)
 end
 

--- a/Glass/constants.lua
+++ b/Glass/constants.lua
@@ -1,20 +1,11 @@
 local _, Constants = unpack(select(2, ...))
 
 -- luacheck: push ignore 113
-local UIParent = UIParent
 local WOW_PROJECT_CLASSIC = WOW_PROJECT_CLASSIC
 local WOW_PROJECT_ID = WOW_PROJECT_ID
 -- luacheck: pop
 
 -- Constants
-Constants.DEFAULT_ANCHOR_POINT = {
-  point = "BOTTOMLEFT",
-  relativeTo = UIParent,
-  relativePoint = "BOTTOMLEFT",
-  xOfs = 20,
-  yOfs = 230
-}
-
 Constants.DOCK_HEIGHT = 20
 Constants.TEXT_XPADDING = 15
 

--- a/Glass/init.lua
+++ b/Glass/init.lua
@@ -36,7 +36,12 @@ function Core:OnInitialize()
     profile = {
       frameWidth = 450,
       frameHeight = 230,
-      positionAnchor = Constants.DEFAULT_ANCHOR_POINT,
+      positionAnchor = {
+        point = "BOTTOMLEFT",
+        relativePoint = "BOTTOMLEFT",
+        xOfs = 20,
+        yOfs = 230
+      },
       font = "Friz Quadrata TT",
       messageFontSize = 12,
       editBoxFontSize = 12,


### PR DESCRIPTION
Do not save the UIParent frame


Issue ticket #XXXX

**If applied, this PR will...**
Stop saving the UIParent table

**Please provide detail on the technical changes, if relevant**
It's not a good idea to save the UIParent table to SavedVariables. It doesn't
really work.

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated