### PR TITLE
Update slide up animation implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fix icons not sliding up (#99)
+
 ## 1.4.1 (2020-09-08)
 
 * Fix AceDB issues

--- a/Glass/Components/FadingFrame.lua
+++ b/Glass/Components/FadingFrame.lua
@@ -18,10 +18,6 @@ function FadingFrameMixin:Init()
     self.fadeIn:SetToAlpha(1)
     self.fadeIn:SetDuration(0)
     self.fadeIn:SetSmoothing("OUT")
-
-    self.showAg:SetScript("OnPlay", function ()
-      self:QuickShow()
-    end)
   end
 
   if self.hideAg == nil then
@@ -62,12 +58,13 @@ function FadingFrameMixin:Show()
     self.hideAg:Stop()
   end
 
-  if not self:IsVisible() then
-    self.showAg:Play()
-  end
-
   if self.hideTimer ~= nil then
     self.hideTimer:Cancel()
+  end
+
+  if not self:IsVisible() then
+    super(self).Show(self)
+    self.showAg:Play()
   end
 end
 

--- a/Glass/Components/SlidingMessageFrame.lua
+++ b/Glass/Components/SlidingMessageFrame.lua
@@ -341,6 +341,12 @@ function SlidingMessageFrameMixin:Init(chatFrame)
 
   Core:Subscribe(UPDATE_CONFIG, function (key)
     if self.state.isCombatLog == false then
+      if key == "font" or key == "messageFontSize" or key == "frameWidth" or key == "frameHeight" then
+        for _, message in ipairs(self.state.messages) do
+            message:UpdateFrame()
+        end
+      end
+
       if key == "frameWidth" or key == "frameHeight" then
         self.config.height = Core.db.profile.frameHeight - Constants.DOCK_HEIGHT - 5
         self.config.width = Core.db.profile.frameWidth
@@ -348,6 +354,10 @@ function SlidingMessageFrameMixin:Init(chatFrame)
         self:SetHeight(self.config.height + self.config.overflowHeight)
         self:SetWidth(self.config.width)
 
+        local contentHeight = reduce(self.state.messages, function (acc, message)
+          return acc + message:GetHeight()
+        end, 0)
+        self.slider:SetHeight(self.config.height + self.config.overflowHeight + contentHeight)
         self.slider:SetWidth(self.config.width)
 
         self.state.scrollAtBottom = true
@@ -356,12 +366,6 @@ function SlidingMessageFrameMixin:Init(chatFrame)
         self:SetVerticalScroll(self:GetVerticalScrollRange() + self.config.overflowHeight)
         self.overlay:Hide()
         self.overlay.newMessageHighlightFrame:Hide()
-      end
-
-      if key == "font" or key == "messageFontSize" or key == "frameWidth" or key == "frameHeight" then
-        for _, message in ipairs(self.state.messages) do
-            message:UpdateFrame()
-        end
       end
 
       if key == "chatBackgroundOpacity" then


### PR DESCRIPTION
Issue ticket #XXXX

**If applied, this PR will...**
Replace animations with libeasing for slide up animations.

**Please provide detail on the technical changes, if relevant**
Previously, the slide up animation was accomplished by animating the slider
(using AnimationGroup). With this change, the animation is accomplished by using
LibEasing on SetVerticalScroll. This was done because doing the previous
approach didn't animate text icons (WoW UI API limitation). Animating the scroll
position with LibEasing gets around this issue.

I haven't noticed any noticeable difference between using LibEasing vs normal
animations.

Also fix an issue with scroll logic being broken after the frame is resized.

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [ ] CHANGELOG updated