### PR TITLE
#102 - In game changelog

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -17,5 +17,5 @@ externals:
     libs/lodash.wow: git://github.com/mixxorz/lodash.wow.git
 
 manual-changelog:
-  filename: CHANGELOG.md
+  filename: LATEST.md
   markup-type: markdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
-## Unreleased (2020-09-13)
+## Unreleased
 
 * Add more customization options (#107)
+* Add in-game changelog (#108)
 
 ## 1.4.2 (2020-09-09)
 

--- a/Glass.toc
+++ b/Glass.toc
@@ -51,5 +51,6 @@ Glass\Components\SlidingMessageFrame.lua
 Glass\Modules\Config.lua
 Glass\Modules\Fonts.lua
 Glass\Modules\Hyperlinks.lua
+Glass\Modules\News.lua
 Glass\Modules\TextProcessing.lua
 Glass\Modules\UIManager.lua

--- a/Glass/Modules/Config.lua
+++ b/Glass/Modules/Config.lua
@@ -1,4 +1,4 @@
-local Core, Constants = unpack(select(2, ...))
+local Core, Constants, Utils = unpack(select(2, ...))
 local C = Core:GetModule("Config")
 
 local AceConfig = Core.Libs.AceConfig
@@ -32,16 +32,54 @@ function C:OnEnable()
           order = 1,
           args = {
             section1 = {
+              name = "Info",
+              type = "group",
+              inline = true,
+              order = 2,
+              args = {
+                version = {
+                  name = " |cffffd100Version:|r  "..Core.Version,
+                  type = "description",
+                  width = "double",
+                  fontSize = "medium",
+                  order = 2.1,
+                },
+                whatsNew = {
+                  name = "What’s new",
+                  type = "execute",
+                  func = function()
+                    Utils.print('Click what new')
+                  end,
+                  order = 2.2,
+                },
+                slashCmd = {
+                  name = "|c00DFBA69/glass|r  |cff808080...............|r  Open config window\n"..
+                         "|c00DFBA69/glass lock|r  |cff808080.......|r  Unlock Glass frame\n",
+                  type = "description",
+                  width = "double",
+                  order = 2.3,
+                },
+                unlockFrame = {
+                  name = "Unlock frame",
+                  type = "execute",
+                  func = function()
+                    Core:Dispatch(UnlockMover())
+                  end,
+                  order = 2.4,
+                },
+              }
+            },
+            section2 = {
               name = "Appearance",
               type = "group",
               inline = true,
-              order = 1,
+              order = 3,
               args = {
                 font = {
                   name = "Font",
                   desc = "Font to use throughout Glass",
                   type = "select",
-                  order = 1.1,
+                  order = 3.1,
                   dialogControl = "LSM30_Font",
                   values = LSM:HashTable("font"),
                   get = function()
@@ -55,7 +93,7 @@ function C:OnEnable()
                 fontFlags = {
                   name = "Font flag",
                   type = "select",
-                  order = 1.2,
+                  order = 3.2,
                   values = FLAGS,
                   get = function ()
                     return Core.db.profile.fontFlags
@@ -67,18 +105,18 @@ function C:OnEnable()
                 }
               },
             },
-            section2 = {
+            section3 = {
               name = "Frame",
               type = "group",
               inline = true,
-              order = 2,
+              order = 4,
               args = {
                 frameWidth = {
                   name = "Width",
                   desc = "Default: "..Core.defaults.profile.frameWidth..
                     "\nMin: 100",
                   type = "range",
-                  order = 2.1,
+                  order = 4.1,
                   min = 100,
                   max = 9999,
                   softMin = 300,
@@ -96,7 +134,7 @@ function C:OnEnable()
                   name = "Height",
                   desc = "Default: "..Core.defaults.profile.frameHeight,
                   type = "range",
-                  order = 2.2,
+                  order = 4.2,
                   min = 1,
                   max = 9999,
                   softMin = 200,
@@ -114,7 +152,7 @@ function C:OnEnable()
                   name = "X offset",
                   desc = "Default: "..Core.defaults.profile.positionAnchor.xOfs,
                   type = "range",
-                  order = 2.3,
+                  order = 4.3,
                   min = -9999,
                   max = 9999,
                   softMin = -2000,
@@ -132,7 +170,7 @@ function C:OnEnable()
                   name = "Y offset",
                   desc = "Default: "..Core.defaults.profile.positionAnchor.yOfs,
                   type = "range",
-                  order = 2.4,
+                  order = 4.4,
                   min = -9999,
                   max = 9999,
                   softMin = -2000,
@@ -150,7 +188,7 @@ function C:OnEnable()
                   name = "Anchor",
                   desc = "Default: "..Core.db.profile.positionAnchor.point,
                   type = "select",
-                  order = 2.5,
+                  order = 4.5,
                   values = ANCHORS,
                   get = function ()
                     return Core.db.profile.positionAnchor.point
@@ -487,6 +525,7 @@ function C:OnEnable()
   }
 
   AceConfig:RegisterOptionsTable("Glass", options)
+  AceConfigDialog:SetDefaultSize("Glass", 780, 500)
 
   self:RegisterChatCommand("glass", "OnSlashCommand")
 

--- a/Glass/Modules/Config.lua
+++ b/Glass/Modules/Config.lua
@@ -6,6 +6,7 @@ local AceConfigDialog = Core.Libs.AceConfigDialog
 local AceDBOptions = Core.Libs.AceDBOptions
 local LSM = Core.Libs.LSM
 
+local OpenNews = Constants.ACTIONS.OpenNews
 local RefreshConfig = Constants.ACTIONS.RefreshConfig
 local UnlockMover = Constants.ACTIONS.UnlockMover
 local UpdateConfig = Constants.ACTIONS.UpdateConfig
@@ -48,7 +49,7 @@ function C:OnEnable()
                   name = "What’s new",
                   type = "execute",
                   func = function()
-                    Utils.print('Click what new')
+                    Core:Dispatch(OpenNews())
                   end,
                   order = 2.2,
                 },

--- a/Glass/Modules/Config.lua
+++ b/Glass/Modules/Config.lua
@@ -1,4 +1,4 @@
-local Core, Constants, Utils = unpack(select(2, ...))
+local Core, Constants = unpack(select(2, ...))
 local C = Core:GetModule("Config")
 
 local AceConfig = Core.Libs.AceConfig

--- a/Glass/Modules/Hyperlinks.lua
+++ b/Glass/Modules/Hyperlinks.lua
@@ -1,6 +1,8 @@
 local Core, Constants = unpack(select(2, ...))
 local Hyperlinks = Core:GetModule("Hyperlinks")
 
+local OpenNews = Constants.ACTIONS.OpenNews
+
 local HYPERLINK_CLICK = Constants.EVENTS.HYPERLINK_CLICK
 local HYPERLINK_ENTER = Constants.EVENTS.HYPERLINK_ENTER
 local HYPERLINK_LEAVE = Constants.EVENTS.HYPERLINK_LEAVE
@@ -11,6 +13,7 @@ local BattlePetTooltip = BattlePetTooltip
 local GameTooltip = GameTooltip
 local ShowUIPanel = ShowUIPanel
 local UIParent = UIParent
+local strsplit = strsplit
 -- luacheck: pop
 
 local linkTypes = {
@@ -30,6 +33,16 @@ function Hyperlinks:OnInitialize()
 end
 
 function Hyperlinks:OnEnable()
+  -- Custom hyperlink for [See what's new]
+  _G.hooksecurefunc("SetItemRef", function(link)
+    local linkType, addon, param1 = strsplit(":", link)
+    if linkType == "garrmission" and addon == "Glass" then
+      if param1 == "opennews" then
+        Core:Dispatch(OpenNews())
+      end
+    end
+  end)
+
   Core:Subscribe(HYPERLINK_CLICK, function (payload)
     local link, text, button = unpack(payload)
     -- Use global reference in case some addon has hooked into it for custom

--- a/Glass/Modules/News.lua
+++ b/Glass/Modules/News.lua
@@ -1,0 +1,132 @@
+local Core, Constants = unpack(select(2, ...))
+local News = Core:GetModule("News")
+
+local AceGUI = Core.Libs.AceGUI
+
+local OPEN_NEWS = Constants.EVENTS.OPEN_NEWS
+
+local CHANGELOG = {
+  {
+    name = "Unreleased (2020-09-13)",
+    items = {
+      "- Add more customization options (#107)"
+    }
+  },
+  {
+    name = "1.4.2 (2020-09-09)",
+    items = {
+      "- Fix icons not sliding up (#99)",
+      "- Fix messages not being displayed sometimes (#99)",
+      "- Fix issues with scrolling after frame resize (#99)",
+    }
+  },
+  {
+    name = "1.4.1 (2020-09-08)",
+    items = {
+      "- Fix AceDB issues"
+    }
+  },
+  {
+    name = "1.4.0 (2020-09-07)",
+    items = {
+      "- Add classic support (#95)"
+    }
+  },
+  {
+    name = "1.3.0 (2020-09-06)",
+    items = {
+      "- Add support for third-party chat links (#90)",
+      "- Improve scrolling behavior (#92)",
+      "- Force chatStyle to classic (#94)",
+    }
+  },
+  {
+    name = "1.2.1 (2020-09-01)",
+    items = {
+      "- Fix conflict with ElvUI Mover",
+    }
+  },
+  {
+    name = "1.2.0 (2020-08-31)",
+    items = {
+      "- Major rearchitecture (#79)",
+      "- Add support for new tab whisper mode (#80)",
+    }
+  },
+  {
+    name = "1.1.1 (2020-08-26)",
+    items = {
+      "- Fix text processing pipeline (#70)",
+      "- Fix jittery animations (#71)",
+      "- Fix dependency issues (#72)",
+    }
+  },
+  {
+    name = "1.1.0 (2020-08-24)",
+    items = {
+      "- Add \"Unlock Window\" option to context menu - SammyJames",
+      "- Add support for Prat timestamps",
+    }
+  },
+  {
+    name = "1.0.1 (2020-08-22)",
+    items = {
+      "- Fix Battle.net toast position",
+      "- Fix some icon textures being squished",
+    }
+  },
+  {
+    name = "1.0.0 (2020-08-22)",
+    items = {
+      "- Initial release",
+    }
+  }
+}
+
+-- Module
+function News:OnEnable()
+  local baseSize = 12
+  local scale = 1.333
+
+  local frame = AceGUI:Create("Frame")
+  frame:SetTitle("Glass: What’s new")
+  frame:SetStatusText("Version: "..Core.Version)
+  frame:SetCallback("OnClose", function(widget) frame:Hide() end)
+  frame:SetLayout("Fill")
+  frame:Hide()
+
+  local scrollFrame = AceGUI:Create("ScrollFrame")
+  scrollFrame:SetLayout("List")
+  frame:AddChild(scrollFrame)
+
+  for _, release in ipairs(CHANGELOG) do
+    local releaseLabel = AceGUI:Create("Label")
+    releaseLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize * scale);
+    releaseLabel:SetRelativeWidth(1)
+    releaseLabel:SetText("|c00DFBA69"..release.name.."|r")
+    scrollFrame:AddChild(releaseLabel)
+
+    for i, item in ipairs(release.items) do
+      local itemLabel = AceGUI:Create("Label")
+      itemLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize);
+      itemLabel:SetRelativeWidth(1)
+
+      local prefix, suffix = "", ""
+
+      if i == 1 then
+        prefix = "\n"
+      end
+
+      if i == #release.items then
+        suffix = "\n"
+      end
+
+      itemLabel:SetText(prefix..item..suffix)
+      scrollFrame:AddChild(itemLabel)
+    end
+  end
+
+  Core:Subscribe(OPEN_NEWS, function ()
+    frame:Show()
+  end)
+end

--- a/Glass/Modules/News.lua
+++ b/Glass/Modules/News.lua
@@ -5,91 +5,125 @@ local AceGUI = Core.Libs.AceGUI
 
 local OPEN_NEWS = Constants.EVENTS.OPEN_NEWS
 
+-- luacheck: push ignore 631
 local CHANGELOG = {
   {
     name = "Unreleased (2020-09-13)",
-    items = {
-      "- Add more customization options (#107)"
-    }
+    items = {[[
+What's new
+
+- New: You can now stick the edit box to the top of the chat window! Very useful if you like chat flush to a bottom corner.
+- New: You no longer need a 16,000 DPI gaming mouse to move Glass to just the right spot. Now you can use sliders for window positioning.
+- New: More control over the font, including leading, line padding, and outline.
+- New: New options for controlling animations. Now you can adjust how fast messages fade in, fade out, and slide in. You can even set these to zero to disable animations completely if that's not your cup of tea.
+
+Bug fixes
+
+- Fixed: Sometimes messages do not appear. This now happens... even less often!
+    ]]}
   },
   {
     name = "1.4.2 (2020-09-09)",
-    items = {
-      "- Fix icons not sliding up (#99)",
-      "- Fix messages not being displayed sometimes (#99)",
-      "- Fix issues with scrolling after frame resize (#99)",
-    }
+    items = {[[
+Bug fixes
+
+- Fixed: Icons in chat messages used to stutter as new messages come in. They now slide smoothly up along with the text. So smooth.
+- Fixed: Sometimes messages do not appear. This now happens... less often!
+- Fixed: Scrolling used to break just after resizing the chat window. This should no longer happen.
+    ]]}
   },
   {
     name = "1.4.1 (2020-09-08)",
-    items = {
-      "- Fix AceDB issues"
-    }
+    items = {[[
+Bug fixes
+
+- Fixed: There was an issue with how Glass saved the window position that was causing AceDB to throw a fit. This issue has been resolved.
+    ]]}
   },
   {
     name = "1.4.0 (2020-09-07)",
-    items = {
-      "- Add classic support (#95)"
-    }
+    items = {[[
+What's new
+
+- New: World of Waracraft Classic is now officially supported!
+    ]]}
   },
   {
     name = "1.3.0 (2020-09-06)",
-    items = {
-      "- Add support for third-party chat links (#90)",
-      "- Improve scrolling behavior (#92)",
-      "- Force chatStyle to classic (#94)",
-    }
+    items = {[[
+What's new
+
+- New: Glass now supports Prat 3.0 URL links! This will now allow you click URL links in chat as long as you have Prat's UrlCopy module enabled.
+- New: Much better scrolling experience. The chat no longer snaps to the bottom when a new message arrives while you're scrolling through history. In addition, we've added a little arrow you can click to go back to your most recent messages. It even tells you when you have unread messages!
+
+Bug fixes
+
+- Fixed: Players have been experiencing issues with the edit box being visible even if it's not focused. This is caused by the chat style setting being set to "IM style". From now on, Glass will automatically set the chat style to "Classic" so that you don't have to do it yourself.
+    ]]}
   },
   {
     name = "1.2.1 (2020-09-01)",
-    items = {
-      "- Fix conflict with ElvUI Mover",
-    }
+    items = {[[
+Bug fixes
+
+- Fixed: There was a conflict with the ElvUI mover and Glass. This has been fixed.
+    ]]}
   },
   {
     name = "1.2.0 (2020-08-31)",
-    items = {
-      "- Major rearchitecture (#79)",
-      "- Add support for new tab whisper mode (#80)",
-    }
+    items = {[[
+What's new
+
+- New: Glass now supports the "New tab" whisper mode! Other "temporary" chat windows are also now supported, including the Pet Battle tab.
+- New: Major architecture changes for Glass. You won't see any changes while using the addon, but rest well in knowing that we've given the engine a massive tune up.
+    ]]}
   },
   {
     name = "1.1.1 (2020-08-26)",
-    items = {
-      "- Fix text processing pipeline (#70)",
-      "- Fix jittery animations (#71)",
-      "- Fix dependency issues (#72)",
-    }
+    items = {[[
+Bug fixes:
+
+- Fixed: You will find that animations are now 99% less jittery!
+- Fixed: Some players were experiencing issues when using Glass with other addons. These issues have been addressed and should no longer happen.
+    ]]}
   },
   {
     name = "1.1.0 (2020-08-24)",
-    items = {
-      "- Add \"Unlock Window\" option to context menu - SammyJames",
-      "- Add support for Prat timestamps",
-    }
+    items = {[[
+What's new
+
+- New: Players have been having a hard time figuring out how to move Glass around. So we've added a new "Unlock Window" option when right-clicking the "General" tab. This is how the default chat UI unlocked its windows so hopefully this will be more obvious.
+- New: Glass now supports Prat Timestamps! If you're using Prat, you should find that timestamps are now displayed.
+    ]]}
   },
   {
     name = "1.0.1 (2020-08-22)",
-    items = {
-      "- Fix Battle.net toast position",
-      "- Fix some icon textures being squished",
-    }
+    items = {[[
+Bug fixes
+
+- Fixed: The Battle.net toast used to be out of place. We've given it a nudge and it should now be where it belongs.
+- Fixed: Previously, some text icons become "squished". We've removed the Squisher Module so you should now see icons in their full, unsquished glory.
+    ]]}
   },
   {
     name = "1.0.0 (2020-08-22)",
-    items = {
-      "- Initial release",
-    }
+    items = {[[
+What's new
+
+- New: Glass exists!
+    ]]}
   }
 }
+-- luacheck: pop
 
 -- Module
 function News:OnEnable()
   local baseSize = 12
-  local scale = 1.333
 
   local frame = AceGUI:Create("Frame")
-  frame:SetTitle("Glass: What’s new")
+  frame:SetTitle("Glass: Version history")
+  frame:SetWidth(600)
+  frame:SetHeight(700)
   frame:SetStatusText("Version: "..Core.Version)
   frame:SetCallback("OnClose", function(widget) frame:Hide() end)
   frame:SetLayout("Fill")
@@ -101,7 +135,7 @@ function News:OnEnable()
 
   for _, release in ipairs(CHANGELOG) do
     local releaseLabel = AceGUI:Create("Label")
-    releaseLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize * scale);
+    releaseLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize);
     releaseLabel:SetRelativeWidth(1)
     releaseLabel:SetText("|c00DFBA69"..release.name.."|r")
     scrollFrame:AddChild(releaseLabel)
@@ -110,6 +144,8 @@ function News:OnEnable()
       local itemLabel = AceGUI:Create("Label")
       itemLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize);
       itemLabel:SetRelativeWidth(1)
+      itemLabel.label:SetSpacing(3)
+      itemLabel.label:SetAlpha(0.9)
 
       local prefix, suffix = "", ""
 

--- a/Glass/Modules/News.lua
+++ b/Glass/Modules/News.lua
@@ -13,9 +13,10 @@ local CHANGELOG = {
 What's new
 
 - New: You can now stick the edit box to the top of the chat window! Very useful if you like chat flush to a bottom corner.
-- New: You no longer need a 16,000 DPI gaming mouse to move Glass to just the right spot. Now you can use sliders for window positioning.
+- New: You no longer need a 16,000 DPI gaming mouse to move Glass to the perfect spot. Now you can use sliders for window positioning.
 - New: More control over the font, including leading, line padding, and outline.
 - New: New options for controlling animations. Now you can adjust how fast messages fade in, fade out, and slide in. You can even set these to zero to disable animations completely if that's not your cup of tea.
+- New: This thing! Glass is getting constant updates with new features and fixes added almost weekly. We thought it would be a good idea to write up changes and new stuff between each release. Watch this space!
 
 Bug fixes
 
@@ -118,12 +119,12 @@ What's new
 
 -- Module
 function News:OnEnable()
-  local baseSize = 12
+  local baseSize = 13
 
   local frame = AceGUI:Create("Frame")
   frame:SetTitle("Glass: Version history")
   frame:SetWidth(600)
-  frame:SetHeight(700)
+  frame:SetHeight(400)
   frame:SetStatusText("Version: "..Core.Version)
   frame:SetCallback("OnClose", function(widget) frame:Hide() end)
   frame:SetLayout("Fill")
@@ -144,8 +145,8 @@ function News:OnEnable()
       local itemLabel = AceGUI:Create("Label")
       itemLabel:SetFont('Fonts\\FRIZQT__.TTF', baseSize);
       itemLabel:SetRelativeWidth(1)
-      itemLabel.label:SetSpacing(3)
-      itemLabel.label:SetAlpha(0.9)
+      itemLabel.label:SetSpacing(3.2)
+      itemLabel.label:SetAlpha(0.95)
 
       local prefix, suffix = "", ""
 

--- a/Glass/Modules/News.lua
+++ b/Glass/Modules/News.lua
@@ -8,7 +8,7 @@ local OPEN_NEWS = Constants.EVENTS.OPEN_NEWS
 -- luacheck: push ignore 631
 local CHANGELOG = {
   {
-    name = "Unreleased (2020-09-13)",
+    name = "Unreleased",
     items = {[[
 What's new
 

--- a/Glass/Modules/UIManager.lua
+++ b/Glass/Modules/UIManager.lua
@@ -74,6 +74,13 @@ function UIManager:OnEnable()
   ChatFrameChannelButton:Hide()
   ChatFrameMenuButton:Hide()
 
+  -- New version alert
+  --[===[@non-debug@
+  if Core.db.global.version == nil or Utils.versionGreaterThan(Core.Version, Core.db.global.version) then
+    Utils.notify('Glass has just been updated. [See what’s new]')
+  end
+  --@end-non-debug@]===]--
+
   -- Force classic chat style
   if GetCVar("chatStyle") ~= "classic" then
     SetCVar("chatStyle", "classic")

--- a/Glass/Modules/UIManager.lua
+++ b/Glass/Modules/UIManager.lua
@@ -77,7 +77,7 @@ function UIManager:OnEnable()
   -- New version alert
   --[===[@non-debug@
   if Core.db.global.version == nil or Utils.versionGreaterThan(Core.Version, Core.db.global.version) then
-    Utils.notify('Glass has just been updated. [See what’s new]')
+    Utils.notify('Glass has just been updated. |cFFFFFF00|Hgarrmission:Glass:opennews|h[See what’s new]|h|r')
   end
   --@end-non-debug@]===]--
 

--- a/Glass/constants.lua
+++ b/Glass/constants.lua
@@ -34,6 +34,7 @@ Constants.EVENTS = {
   LOCK_MOVER = "Glass/LOCK_MOVER",
   MOUSE_ENTER = "Glass/MOUSE_ENTER",
   MOUSE_LEAVE = "Glass/MOUSE_LEAVE",
+  OPEN_NEWS = "Glass/OPEN_NEWS",
   REFRESH_CONFIG = "Glass/REFRESH_CONFIG",
   SAVE_FRAME_POSITION = "Glass/SAVE_FRAME_POSITION",
   UNLOCK_MOVER = "Glass/UNLOCK_MOVER",
@@ -58,6 +59,9 @@ Constants.ACTIONS = {
   end,
   MouseLeave = function ()
     return Constants.EVENTS.MOUSE_LEAVE
+  end,
+  OpenNews = function ()
+    return Constants.EVENTS.OPEN_NEWS
   end,
   RefreshConfig = function ()
     return Constants.EVENTS.REFRESH_CONFIG

--- a/Glass/init.lua
+++ b/Glass/init.lua
@@ -15,11 +15,12 @@ _G[AddonName] = Core
 Core.Libs = {
   AceConfig = _G.LibStub("AceConfig-3.0"),
   AceConfigDialog = _G.LibStub("AceConfigDialog-3.0"),
-  AceDBOptions = _G.LibStub("AceDBOptions-3.0"),
   AceDB = _G.LibStub("AceDB-3.0"),
+  AceDBOptions = _G.LibStub("AceDBOptions-3.0"),
+  AceGUI = _G.LibStub("AceGUI-3.0"),
   AceHook = _G.LibStub("AceHook-3.0"),
-  LibEasing = _G.LibStub("LibEasing-1.0"),
   LSM = _G.LibStub("LibSharedMedia-3.0"),
+  LibEasing = _G.LibStub("LibEasing-1.0"),
   lodash = _G.LibStub("lodash.wow")
 }
 Core.Components = {}
@@ -32,6 +33,7 @@ Core.Version = "DEBUG"
 Core:NewModule("Config", "AceConsole-3.0")
 Core:NewModule("Fonts")
 Core:NewModule("Hyperlinks")
+Core:NewModule("News")
 Core:NewModule("TextProcessing")
 Core:NewModule("UIManager", "AceHook-3.0")
 

--- a/Glass/init.lua
+++ b/Glass/init.lua
@@ -23,6 +23,10 @@ Core.Libs = {
   lodash = _G.LibStub("lodash.wow")
 }
 Core.Components = {}
+Core.Version = "@project-version@"
+--@debug@--
+Core.Version = "DEBUG"
+--@end-debug@--
 
 -- Modules
 Core:NewModule("Config", "AceConsole-3.0")

--- a/Glass/utils.lua
+++ b/Glass/utils.lua
@@ -1,5 +1,11 @@
 local Core, _, Utils = unpack(select(2, ...))
 
+local map = Core.Libs.lodash.map
+
+-- luacheck: push ignore 113
+local strsplit = strsplit
+-- luacheck: pop
+
 -- Utility functions
 Utils.super = function (obj)
   return getmetatable(obj).__index
@@ -20,4 +26,39 @@ end
 -- Prints Glass' notification messages
 Utils.notify = function (message)
   print("|c00DFBA69Glass|r: ", message)
+end
+
+---
+-- Returns true if version is newer
+Utils.versionGreaterThan = function (current, previous)
+  local cur = {strsplit('.', current)}
+  local prev = {strsplit('.', previous)}
+
+  local curPre = {strsplit('-', cur[3])}
+  local prevPre = {strsplit('-', prev[3])}
+
+  cur[3] = curPre[1]
+  prev[3] = prevPre[1]
+
+  cur = map(cur, function (v) return tonumber(v) end)
+  prev = map(prev, function (v) return tonumber(v) end)
+
+  if cur[1] > prev[1] then
+    return true
+  end
+
+  if cur[2] > prev[2] then
+    return true
+  end
+
+  if cur[3] > prev[3] then
+    return true
+  end
+
+  -- Previous was a prerelease
+  if #curPre ~= 2 and #prevPre == 2 then
+    return true
+  end
+
+  return false
 end

--- a/LATEST.md
+++ b/LATEST.md
@@ -1,0 +1,13 @@
+# Unreleased
+
+What's new
+
+- New: You can now stick the edit box to the top of the chat window! Very useful if you like chat flush to a bottom corner.
+- New: You no longer need a 16,000 DPI gaming mouse to move Glass to the perfect spot. Now you can use sliders for window positioning.
+- New: More control over the font, including leading, line padding, and outline.
+- New: New options for controlling animations. Now you can adjust how fast messages fade in, fade out, and slide in. You can even set these to zero to disable animations completely if that's not your cup of tea.
+- New: This thing! Glass is getting constant updates with new features and fixes added almost weekly. We thought it would be a good idea to write up changes and new stuff between each release. Watch this space!
+
+Bug fixes
+
+- Fixed: Sometimes messages do not appear. This now happens... even less often!


### PR DESCRIPTION
Issue ticket #102

**If applied, this PR will...**
Add an in-game changelog for Glass. Whenever a new version of Glass is installed, the first time the game is launched a message comes in that reads "Glass has just been updated. [See what's new]". Clicking the link will open the version history.

**Screenshots**

![Screen Shot 2020-09-14 at 1 44 37 AM](https://user-images.githubusercontent.com/3102758/93024843-de30fb00-f62b-11ea-99c7-d2e607496e98.png)


**Dev checklist**
- [X] Feature works with other addons enabled
- [X] Feature works with all other addons disabled
- [X] README updated (if necessary)
- [x] CHANGELOG updated
