### PR TITLE
#110 - Load initial messages to Glass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Refactor scroll overlay (#109)
 * Refactor new message alert (#109)
 * Refactor OnUpdate handler (#109)
+* Fix GMOTD not displaying (#110)
 
 ## 1.5.0 (2020-09-14)
 

--- a/Glass/Components/SlidingMessageFrame.lua
+++ b/Glass/Components/SlidingMessageFrame.lua
@@ -17,6 +17,7 @@ local UPDATE_CONFIG = Constants.EVENTS.UPDATE_CONFIG
 -- luacheck: push ignore 113
 local CreateFrame = CreateFrame
 local CreateObjectPool = CreateObjectPool
+local DEFAULT_CHAT_FRAME = DEFAULT_CHAT_FRAME
 local Mixin = Mixin
 -- luacheck: pop
 
@@ -188,6 +189,14 @@ function SlidingMessageFrameMixin:Init(chatFrame)
   end, true)
 
   chatFrame:Hide()
+
+  -- Load any messages already in the chat frame to Glass
+  if chatFrame == DEFAULT_CHAT_FRAME then
+    for i = 1, chatFrame:GetNumMessages() do
+        local text, r, g, b = chatFrame:GetMessageInfo(i);
+        self:AddMessage(chatFrame, text, r, g, b);
+      end
+  end
 
   -- Listeners
   if self.subscriptions == nil then


### PR DESCRIPTION
Issue ticket #110

**If applied, this PR will...**
Load initial messages on the default chat frame on Glass

**Dev checklist**
- [x] Feature works with other addons enabled
- [x] Feature works with all other addons disabled
- [x] README updated (if necessary)
- [x] CHANGELOG updated
