### PR TITLE
#139: Rcvd whisper after close breaks whisper tab

### DIFF
--- a/Glass/Components/SlidingMessageFrame.lua
+++ b/Glass/Components/SlidingMessageFrame.lua
@@ -180,9 +180,11 @@ function SlidingMessageFrameMixin:Init(chatFrame)
     self:AddMessage(...)
   end, true)
 
-  self:Hook(chatFrame.historyBuffer, "PushBack", function (_, message)
-    self:BackFillMessage(nil, message.message, message.r, message.g, message.b)
-  end, true)
+  if not self:IsHooked(chatFrame.historyBuffer, "PushBack") then
+    self:Hook(chatFrame.historyBuffer, "PushBack", function (_, message)
+      self:BackFillMessage(nil, message.message, message.r, message.g, message.b)
+    end, true)
+  end
 
   -- Hide the default chat frame and show the sliding message frame instead
   self:RawHook(chatFrame, "Show", function ()


### PR DESCRIPTION
Issue ticket #139 

**If applied, this PR will...**
Prevent a hooking error from occurring when a previously closed whisper tab receives another whisper.

**Please provide detail on the technical changes, if relevant**
Added an "IsHooked" check around the Hook.

**Screenshots**
N/A

**Dev checklist**
- [X] Feature works with other addons enabled
- [ ] Feature works with all other addons disabled
- [ ] README updated (if necessary)
- [ ] CHANGELOG updated
